### PR TITLE
Add support for embedded dead keys in .yaml layouts

### DIFF
--- a/kalamine/utils.py
+++ b/kalamine/utils.py
@@ -25,7 +25,7 @@ def load_data(filename):
                      Loader=yaml.SafeLoader)
 
 
-DEAD_KEYS = load_data('dead_keys.yaml')
+DEFAULT_DEAD_KEYS = load_data('dead_keys.yaml')
 ODK_ID = '**'  # must match the value in dead_keys.yaml
 LAYER_KEYS = [
     '- Digits',


### PR DESCRIPTION
**Use case**: https://github.com/qwerty-fr/qwerty-fr/blob/master/qwerty-fr.yaml

**Limitation**: Linux will still use X11's hardcoded dead keys instead. I'm not sure how to properly implement dead keys on Linux (without compose keys).