### PR TITLE
Add a note on windows encoding issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,12 @@ Build it:
 
     kalamine qwerty-ansi.toml
 
+If you get some UnicodeEncodeError on Windows, try specify this environment variable before executing Kalamine
+
+.. code-block:: powershell
+
+    $Env:PYTHONUTF8 = 1
+
 Get all keyboard drivers:
 
 .. code-block:: bash


### PR DESCRIPTION
I struggle a good 15 minutes trying to understand why Kalamine does not work on Windows. Of course this is due to encoding defaults of the cursed OS.

This may help some users I guess :)

Edit: this is an issue from the yaml library that can't open the data files (like `dead_keys.yaml`)