### PR TITLE
new `xkb/symbols/custom` target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,17 +63,17 @@ Get all keyboard drivers:
 .. code-block:: bash
 
     dist/
-    ├── q-ansi.klc        # Windows
-    ├── q-ansi.keylayout  # macOS
-    ├── q-ansi.xkb        # Linux (user)
-    ├── q-ansi.xkb_patch  # Linux (root)
-    └── q-ansi.json
+     ├─ q-ansi.klc         # Windows
+     ├─ q-ansi.keylayout   # macOS
+     ├─ q-ansi.xkb         # Linux (user)
+     ├─ q-ansi.xkb_custom  # Linux (root)
+     └─ q-ansi.json        # web
 
 You can also ask for a single target by specifying the file extension:
 
 .. code-block:: bash
 
-    kalamine ansi.toml --out q-ansi.xkb_patch
+    kalamine ansi.toml --out q-ansi.xkb_custom
 
 
 Keyboard Layout Installation
@@ -109,7 +109,7 @@ Recent versions of XKB allow *one* custom keyboard layout in root space:
 
 .. code-block:: bash
 
-    sudo cp layout.xkb_patch /usr/share/X11/xkb/symbols/custom
+    sudo cp layout.xkb_custom /usr/share/X11/xkb/symbols/custom
 
 Your keyboard layout will be listed as “Custom” in the keyboard settings.
 

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,29 @@
 Kalamine
 ================================================================================
 
-A cross-platform Keyboard Layout Maker, blatantly stolen from the
-`qwerty-lafayette <https://qwerty-lafayette.org>`_ project.
+A text-based, cross-platform Keyboard Layout Maker.
 
 
-Basic Usage
+Install
 --------------------------------------------------------------------------------
 
-Draw your keyboard layout in ASCII-art and include it in a TOML document:
+All you need is a Python environment:
+
+.. code-block:: bash
+
+   pip install kalamine
+
+If you get a ``UnicodeEncodeError`` on Windows, try specifying this environment variable before executing Kalamine:
+
+.. code-block:: powershell
+
+    $Env:PYTHONUTF8 = 1
+
+
+Keyboard Layout Generation
+--------------------------------------------------------------------------------
+
+Draw your keyboard layout in one of the provided ASCII-art templates and include it in a TOML document:
 
 .. code-block:: toml
 
@@ -55,29 +70,20 @@ Get all keyboard drivers:
     └── q-ansi.json
 
 
-Install
+Keyboard Layout Installation
 --------------------------------------------------------------------------------
 
 Windows
 ```````
 
-* download a keyboard layout installer:
-
-  * either MSKLC_ — proprietary freeware, compatible with Windows XP to 10
-  * or KbdEdit_ — proprietary shareware, compatible with Windows XP to 10
-
+* get a keyboard layout installer: MSKLC_ (freeware) or KbdEdit_ (shareware);
+* load the ``*.klc`` file with it;
 * run this installer to generate a setup program;
 * run the setup program;
 * the keyboard layout appears in the language bar.
 
 .. _MSKLC: https://www.microsoft.com/en-us/download/details.aspx?id=102134
 .. _KbdEdit: http://www.kbdedit.com/
-
-If you get a UnicodeEncodeError, try specifying this environment variable before executing Kalamine:
-
-.. code-block:: powershell
-
-    $Env:PYTHONUTF8 = 1
 
 macOS
 `````
@@ -93,25 +99,25 @@ macOS
 Linux (root) — recommended on Xorg and Wayland
 ````````````
 
-Recent versions of XKB may support *one* custom keyboard layout in root space:
+Recent versions of XKB allow *one* custom keyboard layout in root space:
 
 .. code-block:: bash
 
     sudo cp layout.xkb_patch /usr/share/X11/xkb/symbols/custom
-    setxkbmap custom
 
-Your keyboard layout will be listed as “Custom” in the Gnome keyboard manager, and it should work fine, both on Xorg and Wayland.
+Your keyboard layout will be listed as “Custom” in the keyboard settings.
 
-`setxkbmap` can be used to get back to the standard us-qwerty layout:
+On Xorg you can also select your keyboard layout from the command line:
 
 .. code-block:: bash
 
-    setxkbmap us
+    setxkbmap custom  # select your keyboard layout
+    setxkbmap us      # get back to QWERTY
 
 Linux (user)
 ````````````
 
-On Linux, if the `xkb/symbols/custom` hack can’t be used, ``*.xkb`` keyboard descriptions can be applied in user-space with ``xkbcomp``:
+On Linux, if the ``xkb/symbols/custom`` hack can’t be used, ``*.xkb`` keyboard descriptions can be applied in user-space with ``xkbcomp``:
 
 .. code-block:: bash
 
@@ -119,11 +125,11 @@ On Linux, if the `xkb/symbols/custom` hack can’t be used, ``*.xkb`` keyboard d
 
 This has limitations:
 
-* the keyboard layout won’t show up in the Gnome keyboard manager
+* the keyboard layout won’t show up in the keyboard settings
 * media keys might stop working
 * unlikely to work on Wayland
 
-Again, `setxkbmap` can be used to get back to the standard us-qwerty layout:
+Again, ``setxkbmap`` can be used to get back to the standard us-qwerty layout:
 
 .. code-block:: bash
 
@@ -133,27 +139,38 @@ Again, `setxkbmap` can be used to get back to the standard us-qwerty layout:
 XKalamine
 --------------------------------------------------------------------------------
 
-``xkalamine`` is a Linux-specific tool for managing keyboard layouts with ``xkb``.
+``xkalamine`` is a Linux-specific tool for managing keyboard layouts with XKB.
 
-To apply a keyboard layout in user-space:
+Apply a keyboard layout in user-space (same limitations as ``xkbcomp``):
 
 .. code-block:: bash
 
     # equivalent to `xkbcomp -w10 layout.xkb $DISPLAY`
     xkalamine apply layout.toml
 
-This has limitations: it doesn’t work on Wayland and the keyboard layout doesn’t show up in the Gnome keyboard manager. Besides, on some distros, media keys might stop working.
-
-The proper way to install a keyboard layout on Linux is to modify directly the files in ``/usr/share/X11/xkb``. This is where ``xkalamine`` comes in:
+Install a keyboard layout in ``/usr/share/X11/xkb``:
 
 .. code-block:: bash
 
     sudo xkalamine install layout.toml
 
-There’s also:
+List available keyboard layouts:
 
-* ``xkalamine list`` to enumerate all installed Kalamine layouts
-* ``xkalamine remove`` to uninstall a Kalamine layout
+.. code-block:: bash
+
+    kalamine list             # all kalamine layouts
+    kalamine list fr          # all kalamine layouts for French
+    kalamine list fr --all    # all layouts for French
+    kalamine list --all       # all layouts, ordered by locale
+
+Uninstall a Kalamine layout:
+
+.. code-block:: bash
+
+    sudo xkalamine remove *   # remove all kalamine layouts
+    sudo xkalamine remove fr/lafayette
+
+Using xkalamine with sudo currently supposes kalamine has been installed as root. Which really sucks, and we’re working on a better solution.
 
 XKB is a tricky piece of software. The following resources might be helpful if you want to dig in:
 

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,6 @@ Build it:
 
     kalamine qwerty-ansi.toml
 
-If you get some UnicodeEncodeError on Windows, try specify this environment variable before executing Kalamine
-
-.. code-block:: powershell
-
-    $Env:PYTHONUTF8 = 1
-
 Get all keyboard drivers:
 
 .. code-block:: bash
@@ -56,7 +50,8 @@ Get all keyboard drivers:
     dist/
     ├── q-ansi.klc        # Windows
     ├── q-ansi.keylayout  # macOS
-    ├── q-ansi.xkb        # Linux
+    ├── q-ansi.xkb        # Linux (user)
+    ├── q-ansi.xkb_patch  # Linux (root)
     └── q-ansi.json
 
 
@@ -78,6 +73,12 @@ Windows
 .. _MSKLC: https://www.microsoft.com/en-us/download/details.aspx?id=102134
 .. _KbdEdit: http://www.kbdedit.com/
 
+If you get a UnicodeEncodeError, try specifying this environment variable before executing Kalamine:
+
+.. code-block:: powershell
+
+    $Env:PYTHONUTF8 = 1
+
 macOS
 `````
 
@@ -89,16 +90,40 @@ macOS
 * restart your session;
 * the keyboard layout appears in the “Language and Text” preferences, “Input Methods” tab.
 
-Linux
-`````
+Linux (root) — recommended on Xorg and Wayland
+````````````
 
-On Xorg, ``*.xkb`` keyboard descriptions can be applied with ``xkbcomp``:
+Recent versions of XKB may support *one* custom keyboard layout in root space:
+
+.. code-block:: bash
+
+    sudo cp layout.xkb_patch /usr/share/X11/xkb/symbols/custom
+    setxkbmap custom
+
+Your keyboard layout will be listed as “Custom” in the Gnome keyboard manager, and it should work fine, both on Xorg and Wayland.
+
+`setxkbmap` can be used to get back to the standard us-qwerty layout:
+
+.. code-block:: bash
+
+    setxkbmap us
+
+Linux (user)
+````````````
+
+On Linux, if the `xkb/symbols/custom` hack can’t be used, ``*.xkb`` keyboard descriptions can be applied in user-space with ``xkbcomp``:
 
 .. code-block:: bash
 
     xkbcomp -w10 layout.xkb $DISPLAY
 
-To get back to the standard us-qwerty layout:
+This has limitations:
+
+* the keyboard layout won’t show up in the Gnome keyboard manager
+* media keys might stop working
+* unlikely to work on Wayland
+
+Again, `setxkbmap` can be used to get back to the standard us-qwerty layout:
 
 .. code-block:: bash
 
@@ -129,3 +154,16 @@ There’s also:
 
 * ``xkalamine list`` to enumerate all installed Kalamine layouts
 * ``xkalamine remove`` to uninstall a Kalamine layout
+
+XKB is a tricky piece of software. The following resources might be helpful if you want to dig in:
+
+* https://www.charvolant.org/doug/xkb/html/
+* https://wiki.archlinux.org/title/X_keyboard_extension
+* https://wiki.archlinux.org/title/Xorg/Keyboard_configuration
+* https://github.com/xkbcommon/libxkbcommon/blob/master/doc/keymap-format-text-v1.md
+
+
+Alternative
+--------------------------------------------------------------------------------
+
+https://github.com/39aldo39/klfc

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Build it:
 
 .. code-block:: bash
 
-    kalamine qwerty-ansi.toml
+    kalamine ansi.toml
 
 Get all keyboard drivers:
 
@@ -68,6 +68,12 @@ Get all keyboard drivers:
     ├── q-ansi.xkb        # Linux (user)
     ├── q-ansi.xkb_patch  # Linux (root)
     └── q-ansi.json
+
+You can also ask for a single target by specifying the file extension:
+
+.. code-block:: bash
+
+    kalamine ansi.toml --out q-ansi.xkb_patch
 
 
 Keyboard Layout Installation
@@ -170,7 +176,7 @@ Uninstall a Kalamine layout:
     sudo xkalamine remove *   # remove all kalamine layouts
     sudo xkalamine remove fr/lafayette
 
-Using xkalamine with sudo currently supposes kalamine has been installed as root. Which really sucks, and we’re working on a better solution.
+Using ``xkalamine`` with sudo currently supposes kalamine has been installed as root (hopefully in a pyenv). Which really sucks, and we’re working on a better solution.
 
 XKB is a tricky piece of software. The following resources might be helpful if you want to dig in:
 

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -42,6 +42,12 @@ def make_all(layout, subdir):
         file.write(layout.xkb)
     print('... ' + xkb_path)
 
+    # Linux driver, user-space
+    xkb_custom_path = out_path('.xkb_custom')
+    with open(xkb_custom_path, 'w', encoding='utf-8', newline='\n') as file:
+        file.write(layout.xkb_patch)
+    print('... ' + xkb_custom_path)
+
     # JSON data
     json_path = out_path('.json')
     pretty_json(layout, json_path)

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -72,7 +72,7 @@ def make(input, out):
             continue
 
         # quick output: reuse the input name and change the file extension
-        if out in ['keylayout', 'klc', 'xkb', 'xkb_patch']:
+        if out in ['keylayout', 'klc', 'xkb', 'xkb_custom']:
             output_file = os.path.splitext(input_file)[0] + '.' + out
         else:
             output_file = out
@@ -87,7 +87,7 @@ def make(input, out):
         elif output_file.endswith('.xkb'):
             with open(output_file, 'w', encoding='utf-8', newline='\n') as file:
                 file.write(layout.xkb)
-        elif output_file.endswith('.xkb_patch'):
+        elif output_file.endswith('.xkb_custom'):
             with open(output_file, 'w', encoding='utf-8', newline='\n') as file:
                 file.write(layout.xkb_patch)
         elif output_file.endswith('.json'):

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -72,7 +72,7 @@ def make(input, out):
             continue
 
         # quick output: reuse the input name and change the file extension
-        if out in ['keylayout', 'klc', 'xkb']:
+        if out in ['keylayout', 'klc', 'xkb', 'xkb_patch']:
             output_file = os.path.splitext(input_file)[0] + '.' + out
         else:
             output_file = out
@@ -87,6 +87,9 @@ def make(input, out):
         elif output_file.endswith('.xkb'):
             with open(output_file, 'w', encoding='utf-8', newline='\n') as file:
                 file.write(layout.xkb)
+        elif output_file.endswith('.xkb_patch'):
+            with open(output_file, 'w', encoding='utf-8', newline='\n') as file:
+                file.write(layout.xkb_patch)
         elif output_file.endswith('.json'):
             pretty_json(layout, output_file)
         else:


### PR DESCRIPTION
Following the discussion in #29, @nivopol has pointed me to a quick and straight-forward way to install a keyboard layout on XKB without running kalamine as root:

https://who-t.blogspot.com/2021/02/a-pre-supplied-custom-keyboard-layout.html
https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/189/diffs

Here’s an attempt. It seems to work for me on Xorg (i3) and Wayland (sway): kalamine now produces an `*.xkb_patch` file, which can be sudo-copied to `/usr/share/X11/xkb/symbols/custom`.

It still requires `sudo` but it’s a valuable improvement. One of the cool benefits is that (if supported) this `symbols/custom` file will not be overwritten if the OS updates XKB.