### PR TITLE
Missing dedent dependency

### DIFF
--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -6,6 +6,7 @@ from lxml import etree
 from lxml.builder import E
 from os import environ
 from pathlib import Path
+from textwrap import dedent
 
 
 def xdg_config_home():


### PR DESCRIPTION
`dedent` is from the `textwrap` module and failed to create the `.config/xkb` on archlinux.

This seems to fix it (the module seems to be native and don't require changes in `pyproject.toml`).