### PR TITLE
[xkb] AltGr = Level3_Shift, 1dk = Level5_Latch

### DIFF
--- a/kalamine/data/dead_keys.yaml
+++ b/kalamine/data/dead_keys.yaml
@@ -5,7 +5,9 @@
 
 # The only exception is the '1dk' key, which is:
 #   - a standard dead key for the macOS and Windows drivers;
-#   - a dead AltGr key (ISO_Level3_Latch) for the Linux driver.
+#   - a dead level key  for the Linux driver:
+#     - ISO_Level3_Latch if the layout has no AltGr layer
+#     - ISO_Level5_Latch if the layout uses an AltGr key (= ISO_Level3_Shift).
 
 # All other dead keys have been grep’ed from my Ubuntu 18.04LTS box,
 # excluding multiple diacritic combinations and combining characters.

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -373,14 +373,14 @@ class KeyboardLayout:
     def xkb(self):  # will not work with Wayland
         """ GNU/Linux driver (standalone / user-space) """
         out = load_tpl(self, '.xkb')
-        out = substitute_lines(out, 'LAYOUT', xkb_keymap(self, False))
+        out = substitute_lines(out, 'LAYOUT', xkb_keymap(self, xkbcomp=True))
         return out
 
     @property
     def xkb_patch(self):
-        """ GNU/Linux driver (system patch) """
+        """ GNU/Linux driver (xkb patch, system or user-space) """
         out = load_tpl(self, '.xkb_patch')
-        out = substitute_lines(out, 'LAYOUT', xkb_keymap(self, True))
+        out = substitute_lines(out, 'LAYOUT', xkb_keymap(self, xkbcomp=False))
         return out
 
     ###

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -30,12 +30,13 @@ def xml_proof_id(symbol):
 # - xkb patch for XOrg (system-wide) & Wayland (system-wide/user-space)
 #
 
-def xkb_keymap(layout, eight_levels):
+def xkb_keymap(layout, xkbcomp=False):
     """ Linux layout. """
 
     show_description = True
+    eight_level = layout.has_altgr and layout.has_1dk and not xkbcomp
+    odk_symbol = 'ISO_Level5_Latch' if eight_level else 'ISO_Level3_Latch'
     max_length = 16  # `ISO_Level3_Latch` should be the longest symbol name
-    odk_symbol = 'ISO_Level5_Latch' if eight_levels else 'ISO_Level3_Latch'
 
     output = []
     for key_name in LAYER_KEYS:
@@ -73,15 +74,14 @@ def xkb_keymap(layout, eight_levels):
         key = 'key <{}> {{[ {}, {}, {}, {}]}};'  # 4-level layout by default
         if layout.has_altgr and layout.has_1dk:
             # 6 layers are needed: they won't fit on the 4-level format.
-            # System XKB files require a Neo-like eight-level solution.
-            # Standalone XKB files work best with a dual-group solution:
-            # one 4-level group for base+1dk, one two-level group for AltGr.
-            if eight_levels:  # system XKB file (patch)
+            if xkbcomp:  # user-space XKB file (standalone)
+                # standalone XKB files work best with a dual-group solution:
+                # one 4-level group for base+1dk, one two-level group for AltGr
+                key = 'key <{}> {{[ {}, {}, {}, {}],[ {}, {}]}};'
+            else:  # eight_level XKB patch (Neo-like)
                 key = 'key <{0}> {{[ {1}, {2}, {5}, {6}, {3}, {4}, {7}, {8}]}};'
                 symbols.append('VoidSymbol'.ljust(max_length))
                 symbols.append('VoidSymbol'.ljust(max_length))
-            else:  # user-space XKB file (standalone)
-                key = 'key <{}> {{[ {}, {}, {}, {}],[ {}, {}]}};'
         elif layout.has_altgr:
             del symbols[3]
             del symbols[2]

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -26,8 +26,8 @@ def xml_proof_id(symbol):
 
 ###
 # GNU/Linux: XKB
-# - standalone xkb file to be used by `setxkbcomp` (Xorg only)
-# - system-wide installer script for Xorg & Wayland
+# - standalone xkb file to be used by `xkbcomp` (XOrg only)
+# - xkb patch for XOrg (system-wide) & Wayland (system-wide/user-space)
 #
 
 def xkb_keymap(layout, eight_levels):
@@ -35,6 +35,7 @@ def xkb_keymap(layout, eight_levels):
 
     show_description = True
     max_length = 16  # `ISO_Level3_Latch` should be the longest symbol name
+    odk_symbol = 'ISO_Level5_Latch' if eight_levels else 'ISO_Level3_Latch'
 
     output = []
     for key_name in LAYER_KEYS:
@@ -54,7 +55,7 @@ def xkb_keymap(layout, eight_levels):
                     dk = layout.dead_keys[symbol]
                     desc = dk['alt_self']
                     if dk['char'] == ODK_ID:
-                        symbol = 'ISO_Level3_Latch'
+                        symbol = odk_symbol
                     else:
                         symbol = 'dead_' + dk['name']
                 elif symbol in XKB_KEY_SYM \
@@ -76,7 +77,7 @@ def xkb_keymap(layout, eight_levels):
             # Standalone XKB files work best with a dual-group solution:
             # one 4-level group for base+1dk, one two-level group for AltGr.
             if eight_levels:  # system XKB file (patch)
-                key = 'key <{}> {{[ {}, {}, {}, {}, {}, {}, {}, {}]}};'
+                key = 'key <{0}> {{[ {1}, {2}, {5}, {6}, {3}, {4}, {7}, {8}]}};'
                 symbols.append('VoidSymbol'.ljust(max_length))
                 symbols.append('VoidSymbol'.ljust(max_length))
             else:  # user-space XKB file (standalone)

--- a/kalamine/tpl/base.xkb
+++ b/kalamine/tpl/base.xkb
@@ -20,7 +20,7 @@ xkb_keymap {
   // KALAMINE::GEOMETRY_base
 
   partial alphanumeric_keys modifier_keys
-  xkb_symbols "OneDeadKey" {
+  xkb_symbols "${variant}" {
     include "pc"
 
     name[group1]= "${description}";

--- a/kalamine/tpl/full_1dk.xkb_patch
+++ b/kalamine/tpl/full_1dk.xkb_patch
@@ -22,6 +22,11 @@ xkb_symbols "${variant}" {
     // The AltGr key is an ISO_Level3_Shift:
     include "level3(ralt_switch)"
 
-    // The “OneDeadKey” is an ISO_Level5_Latch:
-    include "level5(modifier_mapping)"
+    // The “OneDeadKey” is an ISO_Level5_Latch, which is activated by this:
+    // (note: MDSW [Mode_switch] is an alias for LVL5 on recent versions of XKB)
+    replace key <MDSW> {
+        type[Group1] = "ONE_LEVEL",
+        symbols[Group1] = [ ISO_Level5_Shift ]
+    };
+    modifier_map Mod3 { <MDSW> };
 };

--- a/kalamine/tpl/full_1dk.xkb_patch
+++ b/kalamine/tpl/full_1dk.xkb_patch
@@ -19,8 +19,9 @@ xkb_symbols "${variant}" {
 
     KALAMINE::LAYOUT
 
-    // The “OneDeadKey” is an ISO_Level3_Latch, i.e. a “dead AltGr” key:
-    // this is the only way to have a multi-purpose dead key with XKB.
-    // The real AltGr key is an ISO_Level5_Switch.
-    include "level5(ralt_switch)"
+    // The AltGr key is an ISO_Level3_Shift:
+    include "level3(ralt_switch)"
+
+    // The “OneDeadKey” is an ISO_Level5_Latch:
+    include "level5(modifier_mapping)"
 };


### PR DESCRIPTION
Until now, kalamine used to generate XKB layouts where the AltGr key was an `ISO_Level5_Shift`, and the `1dk` was an `ISO_Level3_Latch`. This is unnatural and possibly confusing, e.g. :
- Gnome Tweaks sets the AltGr key to a Level3 shift by default
- the Compose key seems to always work with Level3 symbols, but not always with Level5

The reason for this was that I had never been able to make an `ISO_Level5_Latch` work… until now. And it’s so simple that I really can’t figure out how I could’ve missed that.

Anyway. Here’s a quick patch to test it. Let’s find out if it breaks [on older systems](https://lists.x.org/archives/xorg-devel/2011-August/024223.html).