### PR TITLE
[klc] ignore ABNT and JIS keys (unsupported)

### DIFF
--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -117,6 +117,9 @@ def klc_keymap(layout):
         if key_name.startswith('-'):
             continue
 
+        if key_name in ['ae13', 'ab11']:  # ABNT / JIS keys
+            continue  # these two keys are not supported yet
+
         symbols = []
         description = '//'
         alpha = False


### PR DESCRIPTION
Fixes #62… sort of. We still need to generate proper codes for these keys in order to support ABNT and JIS keyboards.