### PR TITLE
Enable SVG output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,34 @@
+.PHONY: all dev test lint publish format clean
+
 all: test
 
-test:
-	kalamine layouts/*.toml
+dev:  ## Install a development environment
+	# python3 -m pip install --user --upgrade twine wheel
+	python3 -m pip install --user --upgrade build
+	python3 -m pip install --user -e .
+
+
+test:  ## Run tests
+	python -m kalamine.cli layouts/*.toml
 	pytest
 
-clean:
-	rm -rf build
-	rm -rf dist
-	rm -rf include
-	rm -rf kalamine.egg-info
-	rm -rf kalamine/__pycache__
-
-lint:
-	flake8 kalamine
-
-publish: test
+publish: test  ## Publish package
 	# flake8 kalamine
 	rm -rf dist/*
 	python3 -m build
 	twine check dist/*
 	twine upload dist/*
 
-dev:
-	# python3 -m pip install --user --upgrade twine wheel
-	python3 -m pip install --user --upgrade build
-	python3 -m pip install --user -e .
+lint:  ## Lint sources
+	flake8 kalamine
+
+format:  ## Format sources
+	isort .
+	black .
+
+clean:  ## Clean sources
+	rm -rf build
+	rm -rf dist
+	rm -rf include
+	rm -rf kalamine.egg-info
+	rm -rf kalamine/__pycache__

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -4,6 +4,8 @@ import os
 from importlib import metadata
 
 import click
+from lxml import etree
+from lxml.builder import E
 
 from .layout import KeyboardLayout
 from .server import keyboard_server
@@ -64,6 +66,11 @@ def make_all(layout, subdir):
     pretty_json(layout, json_path)
     print("... " + json_path)
 
+    # SVG data
+    svg_path = out_path('.svg')
+    layout.svg.write(svg_path, pretty_print=True, encoding='utf-8')
+    print('... ' + svg_path)
+
 
 @click.command()
 @click.argument("input", nargs=-1, type=click.Path(exists=True))
@@ -90,7 +97,7 @@ def make(input, version, watch, out):
             continue
 
         # quick output: reuse the input name and change the file extension
-        if out in ["keylayout", "klc", "xkb", "xkb_custom"]:
+        if out in ['keylayout', 'klc', 'xkb', 'xkb_custom', 'svg']:
             output_file = os.path.splitext(input_file)[0] + "." + out
         else:
             output_file = out
@@ -114,6 +121,8 @@ def make(input, version, watch, out):
                 file.write(layout.xkb_patch)
         elif output_file.endswith(".json"):
             pretty_json(layout, output_file)
+        elif output_file.endswith('.svg'):
+            layout.svg.write(output_file, pretty_print=True, encoding='utf-8')
         else:
             print("Unsupported output format.")
             return

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -4,8 +4,6 @@ import os
 from importlib import metadata
 
 import click
-from lxml import etree
-from lxml.builder import E
 
 from .layout import KeyboardLayout
 from .server import keyboard_server

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -67,9 +67,9 @@ def make_all(layout, subdir):
     print("... " + json_path)
 
     # SVG data
-    svg_path = out_path('.svg')
-    layout.svg.write(svg_path, pretty_print=True, encoding='utf-8')
-    print('... ' + svg_path)
+    svg_path = out_path(".svg")
+    layout.svg.write(svg_path, pretty_print=True, encoding="utf-8")
+    print("... " + svg_path)
 
 
 @click.command()
@@ -121,8 +121,8 @@ def make(input, version, watch, out):
                 file.write(layout.xkb_patch)
         elif output_file.endswith(".json"):
             pretty_json(layout, output_file)
-        elif output_file.endswith('.svg'):
-            layout.svg.write(output_file, pretty_print=True, encoding='utf-8')
+        elif output_file.endswith(".svg"):
+            layout.svg.write(output_file, pretty_print=True, encoding="utf-8")
         else:
             print("Unsupported output format.")
             return

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -97,7 +97,7 @@ def make(input, version, watch, out):
             continue
 
         # quick output: reuse the input name and change the file extension
-        if out in ['keylayout', 'klc', 'xkb', 'xkb_custom', 'svg']:
+        if out in ["keylayout", "klc", "xkb", "xkb_custom", "svg"]:
             output_file = os.path.splitext(input_file)[0] + "." + out
         else:
             output_file = out

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -439,7 +439,7 @@ class KeyboardLayout:
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
                 # Print 1-4 level chars
                 for level_num, char in enumerate(chars, start=1):
-                    if chars[0] == chars[1].lower() and level_num == 1 and char != "**":
+                    if chars[0] == chars[1].lower() and level_num == 1 :
                         # Do not print letters twice (lower and upper)
                         continue
 

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -454,7 +454,6 @@ class KeyboardLayout:
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
                     ):
                         if char not in deadkeys:
-                            # Not a deadkey
                             location.text = char
                         else:
                             location.text = (

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -433,7 +433,7 @@ class KeyboardLayout:
         # Get Layout data
         keymap = web_keymap(self)
         deadkeys = web_deadkeys(self)
-
+        # breakpoint()
         # Fill-in with layout
         for name, chars in keymap.items():
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
@@ -446,17 +446,21 @@ class KeyboardLayout:
                     for location in key.xpath(
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
                     ):
-                        location.text = char
-                        if char in deadkeys:
+                        if char not in deadkeys:
+                            # Not a deadkey
+                            location.text = char
+                        else:
+                            location.text = "★" if char == "**" else char.removeprefix("*")
                             # Apply special class for deadkeys
                             location.set("class", location.get("class") + " deadKey diacritic")
 
                 # Print 5-6 levels (1dk deadkeys)
-                for level_num, char in enumerate(chars[:2], start=5):
-                    if dead_char := deadkeys["**"].get(char):
-                        for location in key.xpath(
-                            f"svg:g/svg:text[@class='level{level_num} dk']", namespaces=ns
-                        ):
-                            location.text = dead_char
+                if deadkeys and (main_deadkey:= deadkeys.get("**")):
+                    for level_num, char in enumerate(chars[:2], start=5):
+                        if dead_char := main_deadkey.get(char):
+                            for location in key.xpath(
+                                f"svg:g/svg:text[@class='level{level_num} dk']", namespaces=ns
+                            ):
+                                location.text = dead_char
 
         return svg

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -22,7 +22,14 @@ from .template import (
     web_keymap,
     xkb_keymap,
 )
-from .utils import DEAD_KEYS, ODK_ID, lines_to_text, load_data, open_local_file, text_to_lines
+from .utils import (
+    DEAD_KEYS,
+    ODK_ID,
+    lines_to_text,
+    load_data,
+    open_local_file,
+    text_to_lines,
+)
 
 ###
 # Helpers
@@ -439,7 +446,7 @@ class KeyboardLayout:
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
                 # Print 1-4 level chars
                 for level_num, char in enumerate(chars, start=1):
-                    if chars[0] == chars[1].lower() and level_num == 1 :
+                    if chars[0] == chars[1].lower() and level_num == 1:
                         # Do not print letters twice (lower and upper)
                         continue
 
@@ -450,16 +457,21 @@ class KeyboardLayout:
                             # Not a deadkey
                             location.text = char
                         else:
-                            location.text = "★" if char == "**" else char.removeprefix("*")
+                            location.text = (
+                                "★" if char == "**" else char.removeprefix("*")
+                            )
                             # Apply special class for deadkeys
-                            location.set("class", location.get("class") + " deadKey diacritic")
+                            location.set(
+                                "class", location.get("class") + " deadKey diacritic"
+                            )
 
                 # Print 5-6 levels (1dk deadkeys)
-                if deadkeys and (main_deadkey:= deadkeys.get("**")):
+                if deadkeys and (main_deadkey := deadkeys.get("**")):
                     for level_num, char in enumerate(chars[:2], start=5):
                         if dead_char := main_deadkey.get(char):
                             for location in key.xpath(
-                                f"svg:g/svg:text[@class='level{level_num} dk']", namespaces=ns
+                                f"svg:g/svg:text[@class='level{level_num} dk']",
+                                namespaces=ns,
                             ):
                                 location.text = dead_char
 

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -226,7 +226,7 @@ class KeyboardLayout:
                     break
             # copy the 2nd and 3rd layers to the dead key
             for i in [0, 1]:
-                for (name, alt_char) in self.layers[i + 2].items():
+                for name, alt_char in self.layers[i + 2].items():
                     base_char = self.layers[i][name]
                     if name != "spce" and base_char != ODK_ID:
                         odk["base"] += base_char
@@ -418,18 +418,17 @@ class KeyboardLayout:
             "altgr": self.has_altgr,
         }
 
-
     ###
     # SVG output
     #
 
     @property
     def svg(self):
-        """ SVG drawing """
+        """SVG drawing"""
         # Parse SVG data
-        filepath = os.path.join(os.path.dirname(__file__), 'tpl', 'x-keyboard.svg')
+        filepath = os.path.join(os.path.dirname(__file__), "tpl", "x-keyboard.svg")
         svg = etree.parse(filepath, etree.XMLParser(remove_blank_text=True))
-        ns = {'svg': 'http://www.w3.org/2000/svg'}
+        ns = {"svg": "http://www.w3.org/2000/svg"}
 
         # Get Layout data
         keymap = web_keymap(self)
@@ -438,7 +437,6 @@ class KeyboardLayout:
         # Fill-in with layout
         for name, chars in keymap.items():
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
-
                 # Print 1-4 level chars
                 for level_num, char in enumerate(chars, start=1):
                     if chars[0] == chars[1].lower() and level_num == 1 and char != "**":
@@ -446,26 +444,19 @@ class KeyboardLayout:
                         continue
 
                     for location in key.xpath(
-                            f"svg:g/svg:text[@class='level{level_num}']",
-                            namespaces=ns
-                        ):
-
+                        f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
+                    ):
                         location.text = char
                         if char in deadkeys:
                             # Apply special class for deadkeys
                             location.set("class", location.get("class") + " deadKey diacritic")
 
-
                 # Print 5-6 levels (1dk deadkeys)
                 for level_num, char in enumerate(chars[:2], start=5):
-                    if (dead_char:= deadkeys["**"].get(char)):
+                    if dead_char := deadkeys["**"].get(char):
                         for location in key.xpath(
-                            f"svg:g/svg:text[@class='level{level_num} dk']",
-                            namespaces=ns
+                            f"svg:g/svg:text[@class='level{level_num} dk']", namespaces=ns
                         ):
-
                             location.text = dead_char
 
-
         return svg
-

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -6,6 +6,7 @@ import sys
 
 import tomli
 import yaml
+from lxml import etree
 
 from .template import (
     ahk_keymap,
@@ -20,14 +21,7 @@ from .template import (
     web_keymap,
     xkb_keymap,
 )
-from .utils import (
-    DEAD_KEYS,
-    ODK_ID,
-    lines_to_text,
-    load_data,
-    open_local_file,
-    text_to_lines,
-)
+from .utils import DEAD_KEYS, ODK_ID, lines_to_text, load_data, open_local_file, text_to_lines
 
 ###
 # Helpers
@@ -422,3 +416,26 @@ class KeyboardLayout:
             "deadkeys": web_deadkeys(self),
             "altgr": self.has_altgr,
         }
+
+
+    ###
+    # SVG output
+    #
+
+    @property
+    def svg(self):
+        """ SVG drawing """
+        filepath = os.path.join(os.path.dirname(__file__), 'tpl', 'x-keyboard.svg')
+        svg = etree.parse(filepath, etree.XMLParser(remove_blank_text=True))
+        ns = {'svg': 'http://www.w3.org/2000/svg'}
+
+        # for key in svg.xpath('//svg:text[starts-with(@class, "level")]', namespaces=ns):
+        #     key.text = ''
+
+        for (name, chars) in web_keymap(self).items():
+            for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
+                for lv2 in key.xpath('svg:g/svg:text[@class="level2"]', namespaces=ns):
+                    lv2.text = chars[1]
+
+        return svg
+

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import re
 import sys
+from typing import Any
 
 import tomli
 import yaml
@@ -425,17 +426,46 @@ class KeyboardLayout:
     @property
     def svg(self):
         """ SVG drawing """
+        # Parse SVG data
         filepath = os.path.join(os.path.dirname(__file__), 'tpl', 'x-keyboard.svg')
         svg = etree.parse(filepath, etree.XMLParser(remove_blank_text=True))
         ns = {'svg': 'http://www.w3.org/2000/svg'}
 
-        # for key in svg.xpath('//svg:text[starts-with(@class, "level")]', namespaces=ns):
-        #     key.text = ''
+        # Get Layout data
+        keymap = web_keymap(self)
+        deadkeys = web_deadkeys(self)
 
-        for (name, chars) in web_keymap(self).items():
+        # Fill-in with layout
+        for name, chars in keymap.items():
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
-                for lv2 in key.xpath('svg:g/svg:text[@class="level2"]', namespaces=ns):
-                    lv2.text = chars[1]
+
+                # Print 1-4 level chars
+                for level_num, char in enumerate(chars, start=1):
+                    if chars[0] == chars[1].lower() and level_num == 1 and char != "**":
+                        # Do not print letters twice (lower and upper)
+                        continue
+
+                    for location in key.xpath(
+                            f"svg:g/svg:text[@class='level{level_num}']",
+                            namespaces=ns
+                        ):
+
+                        location.text = char
+                        if char in deadkeys:
+                            # Apply special class for deadkeys
+                            location.set("class", location.get("class") + " deadKey diacritic")
+
+
+                # Print 5-6 levels (1dk deadkeys)
+                for level_num, char in enumerate(chars[:2], start=5):
+                    if (dead_char:= deadkeys["**"].get(char)):
+                        for location in key.xpath(
+                            f"svg:g/svg:text[@class='level{level_num} dk']",
+                            namespaces=ns
+                        ):
+
+                            location.text = dead_char
+
 
         return svg
 

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -424,7 +424,7 @@ def osx_actions(layout):
     def append_actions(symbol, actions):
         ret_actions.append(f'<action id="{xml_proof_id(symbol)}">')
         ret_actions.append(when("none", symbol))
-        for (state, out) in actions:
+        for state, out in actions:
             ret_actions.append(when(state, out))
         ret_actions.append("</action>")
 

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 import json
+from typing import TYPE_CHECKING
 
 from .utils import LAYER_KEYS, ODK_ID, load_data
+
+if TYPE_CHECKING:
+    from .layout import KeyboardLayout
 
 ###
 # Helpers
@@ -500,9 +504,14 @@ def osx_terminators(layout):
 # https://github.com/fabi1cazenave/x-keyboard
 #
 
+def web_keymap(layout: "KeyboardLayout") -> dict[str, list[str]]:
+    """Web layout, main part.
 
-def web_keymap(layout):
-    """Web layout, main part."""
+    Returns
+    -------
+    dict[str, list[str]]
+        A dict whose keys are key ids and values are list of characters (length 2-4).
+    """
 
     keymap = {}
     for key_name in LAYER_KEYS:
@@ -518,8 +527,14 @@ def web_keymap(layout):
     return keymap
 
 
-def web_deadkeys(layout):
-    """Web layout, dead keys."""
+def web_deadkeys(layout: "KeyboardLayout") -> dict[str, dict[str, str]]:
+    """Web layout, dead keys.
+
+    Returns
+    -------
+    dict[str, dict[str, str]]
+        A dict whose keys are deadkeys and values are key mapping.
+    """
 
     deadkeys = {}
     if layout.has_1dk:  # ensure 1dk is first in the dead key dictionary

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -504,6 +504,7 @@ def osx_terminators(layout):
 # https://github.com/fabi1cazenave/x-keyboard
 #
 
+
 def web_keymap(layout: "KeyboardLayout") -> dict[str, list[str]]:
     """Web layout, main part.
 
@@ -539,7 +540,7 @@ def web_deadkeys(layout: "KeyboardLayout") -> dict[str, dict[str, str]]:
     deadkeys = {}
     if layout.has_1dk:  # ensure 1dk is first in the dead key dictionary
         deadkeys[ODK_ID] = {}
-    for (id, dk) in layout.dead_keys.items():
+    for id, dk in layout.dead_keys.items():
         deadkeys[id] = {}
         deadkeys[id][id] = dk["alt_self"]
         deadkeys[id]["\u0020"] = dk["alt_space"]

--- a/kalamine/tpl/x-keyboard.svg
+++ b/kalamine/tpl/x-keyboard.svg
@@ -1,3 +1,4 @@
+<!-- dk altgr-->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" platform="gnu" theme="" class="iso intlBackslash">
   <style>
     rect, path {
@@ -236,7 +237,7 @@
 
     /* dimmed AltGr + bold dead keys */
     .level3, .level4 { fill: blue; opacity: .5; }
-    .level5, .level6 { fill: green; }
+    .level5, .level6 { fill: green; display: none }
     .deadKey {
       fill: red;
       font-size: 14px;
@@ -252,9 +253,9 @@
 
     /* highlight AltGr + Dead Keys */
     .dk .level1, .altgr .level1,
-    .dk .level2, .altgr .level2 { opacity: 0.25; }
+    .dk .level2, .altgr .level2 { opacity: 0.25; display: block; }
     .dk .level5, .altgr .level3,
-    .dk .level6, .altgr .level4 { opacity: 1; }
+    .dk .level6, .altgr .level4 { opacity: 1; display: block;}
     .dk .level3,
     .dk .level4 { display: none; }
 
@@ -536,7 +537,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>
@@ -569,7 +570,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>
@@ -580,7 +581,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>
@@ -736,7 +737,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2 deadKey" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>
@@ -790,7 +791,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>
@@ -869,7 +870,7 @@
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
           <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
-          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
           <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
         </g>

--- a/kalamine/tpl/x-keyboard.svg
+++ b/kalamine/tpl/x-keyboard.svg
@@ -46,6 +46,10 @@
   | 1  5 |
   ========
 
+  Mixed display
+  +++++++++++++
+
+  Adding mixed class to main svg tag shows a mixed view with altgr and 1dk layers.
   -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" platform="gnu" theme="" class="iso intlBackslash">
   <style>
@@ -303,9 +307,13 @@
     .dk .level1, .altgr .level1,
     .dk .level2, .altgr .level2 { opacity: 0.25; display: block; }
     .dk .level5, .altgr .level3,
-    .dk .level6, .altgr .level4 { opacity: 1; display: block;}
-    .dk .level3,
-    .dk .level4 { display: none; }
+    .dk .level6, .altgr .level4,
+    .mixed .level3, .mixed .level5 { opacity: 1; display: block;}
+    .dk .level3, .dk .level4,
+    .mixed .level4, .mixed .level6 { display: none; }
+
+    /* Translate level5 upward if mixed */
+    .mixed .level5 {transform: translate(0px, -22.8px);}
 
     @media (prefers-color-scheme: dark) {
       rect, path { stroke: #777; fill: #444; }

--- a/kalamine/tpl/x-keyboard.svg
+++ b/kalamine/tpl/x-keyboard.svg
@@ -1,4 +1,52 @@
-<!-- dk altgr-->
+<!--
+  How to use this SVG?
+  ====================
+
+  The layers
+  ++++++++++
+
+  This SVG has 6 layers by key:
+  - layer 1 : No mod
+  - layer 2 : Maj
+  - layer 3 : AltGr
+  - layer 4 : AltGr + Maj
+  - layer 5 (dk) : dk
+  - layer 6 (dk) : dk + Maj
+
+  Layers 5 and 6 correspond to main deadkey. Other deadkeys are not represented.
+
+  Default display
+  +++++++++++++++
+
+  The default display represents layers on a key like this.
+
+  ========
+  | 2  4 |
+  |      |
+  | 1  3 |
+  ========
+
+  AltGr display
+  +++++++++++++
+
+  If `altgr` is added as a class to base `svg` tag, the layers display
+  like default display except layers 3 and 4 are highlighted.
+
+  Deadkey display
+  +++++++++++++++
+
+  Deadkeys are represented as red characters in different layers.
+
+  Adding classes to base `svg` tag replaces layers 3 and 4 with main deadkey
+  layers and highlight them. The keys are represented as:
+
+  ========
+  | 2  6 |
+  |      |
+  | 1  5 |
+  ========
+
+  -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" platform="gnu" theme="" class="iso intlBackslash">
   <style>
     rect, path {
@@ -735,7 +783,7 @@
         <rect class="" width="52" height="52" rx="5" ry="5"/>
         <g class="key">
           <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
-          <text class="level2 deadKey" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
           <text class="level3" width="22" height="22" x="38" y="43.4"></text>
           <text class="level4" width="22" height="22" x="38" y="20.6"></text>
           <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>

--- a/kalamine/tpl/x-keyboard.svg
+++ b/kalamine/tpl/x-keyboard.svg
@@ -1,0 +1,993 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" platform="gnu" theme="" class="iso intlBackslash">
+  <style>
+    rect, path {
+      stroke: #666;
+      stroke-width: .5px;
+      fill: #f8f8f8;
+    }
+    .specialKey,
+    .specialKey rect,
+    .specialKey path {
+      fill: #e4e4e4;
+    }
+    text {
+      fill: #333;
+      font: normal 20px sans-serif;
+      text-align: center;
+    }
+    #Backspace text {
+      font-size: 12px;
+    }
+
+    #Escape { display: none; }
+
+    #row_AE { transform: translate(4px, 4px); }
+    #row_AD { transform: translate(4px, 64px); }
+    #row_AC { transform: translate(4px, 124px); }
+    #row_AB { transform: translate(4px, 184px); }
+    #row_AA { transform: translate(4px, 244px); }
+
+    /* Backslash + Enter */
+    #Enter path.alt,
+    #Enter     .iso,
+    #Backslash .iso,
+    .alt #Enter rect.ansi,
+    .iso #Enter rect.ansi,
+    .iso #Enter text.ansi,
+    .alt #Backslash .ansi,
+    .iso #Backslash .ansi { display: none; }
+    #Enter text.ansi,
+    .alt #Enter     .alt,
+    .iso #Enter     .iso,
+    .iso #Backslash .iso { display: block; }
+    .iso #Backslash { transform: translate(765px, 60px); }
+    .alt #Backslash { transform: translate(780px, -60px); }
+
+    /* Backspace + IntlYen */
+    #IntlYen, #Backspace .alt,
+    .intlYen  #Backspace .ansi { display: none; }
+    .intlYen  #Backspace .alt,
+    .intlYen  #IntlYen { display: block; }
+
+    /* ShiftLeft + IntlBackslash */
+    #IntlBackslash, #ShiftLeft .iso,
+    .intlBackslash  #ShiftLeft .ansi { display: none; }
+    .intlBackslash  #ShiftLeft .iso,
+    .intlBackslash  #IntlBackslash { display: block; }
+
+    /* ShiftRight + IntlRo */
+    #IntlRo, #ShiftRight .abnt,
+    .intlRo  #ShiftRight .ansi { display: none; }
+    .intlRo  #ShiftRight .abnt,
+    .intlRo  #IntlRo { display: block; }
+
+    .specialKey   .ergo,
+    .specialKey   .ol60,
+    .specialKey   .ol50,
+    .specialKey   .ol40,
+    #Space        .ol60,
+    #Space        .ol50,
+    #Space        .ol40,
+    #Backquote    .ol60,
+    #BracketRight .ol60,
+    #Equal        .ol60,
+    .ergo #CapsLock,
+    .ergo #Space      rect,
+    .ergo #Backslash  rect,
+    .ergo .specialKey rect,
+    .ergo .specialKey text { display: none; }
+    .ol50 #Escape,
+    .ol40 #Escape,
+    .ol60 #Space        .ol60,
+    .ol50 #Space        .ol50,
+    .ol40 #Space        .ol40,
+    .ol60 #Backquote    .ol60,
+    .ol60 #BracketRight .ol60,
+    .ol60 #Backslash    .ol60,
+    .ol60 #Equal        .ol60,
+    .ol60 .specialKey   .ol60,
+    .ol50 .specialKey   .ol50,
+    .ol40 .specialKey   .ol40,
+    .ergo .specialKey   .ergo { display: block; }
+
+    .ol50 .pinkyKey, .ol50 #ContextMenu,
+    .ol40 .pinkyKey, .ol40 #ContextMenu,
+    .ol40 #row_AE .numberKey { display: none; }
+
+    .ergo #row_AE       { transform: translate(94px, 4px); }
+    .ergo #row_AD       { transform: translate(64px, 64px); }
+    .ergo #row_AC       { transform: translate(49px, 124px); }
+    .ergo #row_AB       { transform: translate(19px, 184px); }
+
+    .ergo #Tab          { transform: translate(15px, 0px); }
+    .ergo #ShiftLeft    { transform: translate(60px, 0px); }
+    .ergo #ControlLeft  { transform: translate(75px, 0px); }
+    .ergo #MetaLeft     { transform: translate(150px, 0px); }
+    .ergo #AltLeft      { transform: translate(240px, 0px); }
+    .ergo #Space        { transform: translate(315px, 0px); }
+    .ergo #AltRight     { transform: translate(540px, 0px); }
+    .ergo #MetaRight    { transform: translate(630px, 0px); }
+    .ergo #ControlRight { transform: translate(750px, 0px); }
+
+    .ergo .left         { transform: translate(-15px, 0px); }
+    .ergo .right        { transform: translate(15px, 0px); }
+
+    .ol60 .left         { transform: translate(-75px, 0px); }
+    .ol60 #ControlRight { transform: translate(810px, 0px); }
+    .ol60 #Backquote    { transform: translate(-15px, 0px); }
+    .ol60 #ShiftRight   { transform: translate(795px, 0px); }
+    .ol60 #ContextMenu  { transform: translate(750px, 0px); }
+    .ol60 #Backslash    { transform: translate(690px, 120px); }
+    .ol60 #Backspace    { transform: translate(277.5px, 60px); }
+    .ol60 #Enter        { transform: translate(322.5px, 60px); }
+
+    .ol50 #Escape       { transform: translate(-15px, 0px); }
+    .ol50 #Backspace    { transform: translate(660px, 0px); }
+    .ol50 #Enter        { transform: translate(705px, -60px); }
+
+    .ol40 #Escape       { transform: translate(-15px, 120px); }
+    .ol40 #Backspace    { transform: translate(660px, 60px); }
+    .ol40 #Enter        { transform: translate(705px, 0px); }
+
+    [platform="gnu"].ergo .specialKey .win,
+    [platform="gnu"].ergo .specialKey .mac,
+    [platform="win"].ergo .specialKey .gnu,
+    [platform="win"].ergo .specialKey .mac { display: none; }
+    .ergo .specialKey .mac,
+    [platform="gnu"].ergo .specialKey .gnu,
+    [platform="win"].ergo .specialKey .win { display: block; }
+
+    /* swap Alt/Meta for MacOSX */
+    [platform="gnu"].ergo #MetaLeft,
+    [platform="win"].ergo #MetaLeft,
+                    .ergo #AltLeft   { transform: translate(150px, 0px); }
+    [platform="gnu"].ergo #AltLeft,
+    [platform="win"].ergo #AltLeft,
+                    .ergo #MetaLeft  { transform: translate(240px, 0px); }
+    [platform="gnu"].ergo #AltRight,
+    [platform="win"].ergo #AltRight,
+                    .ergo #MetaRight { transform: translate(570px, 0px); }
+    [platform="gnu"].ergo #MetaRight,
+    [platform="win"].ergo #MetaRight,
+                    .ergo #AltRight  { transform: translate(660px, 0px); }
+
+    #NonConvert, #Convert, #KanaMode,
+    #Lang1, #Lang2,
+    #Space .jis,
+    #Space .ks,
+    .ks  #Space .ansi,
+    .ks  #Space .jis,
+    .jis #Space .ansi,
+    .jis #Space .ks { display: none; }
+    .ks  #Space .ks,
+    .jis #NonConvert, .jis #Convert, .jis #KanaMode,
+    .ks #Lang1, .ks #Lang2,
+    .jis #Space .jis { display: block; }
+
+    #Backquote .jis,
+    #CapsLock  .jis,
+    .jis #Backquote .ansi,
+    .jis #CapsLock  .ansi { display: none; }
+    .jis #Backquote .jis,
+    .jis #CapsLock .jis { display: block; }
+
+    #Lang1 text,
+    #Lang2 text,
+    #Convert text,
+    #NonConvert text,
+    .jis #CapsLock text { font-size: 14px; }
+    #KanaMode text,
+    .jis #Backquote text { font-size: 10px; }
+
+    .specialKey .win,
+    .specialKey .gnu {
+      display: none;
+      font-size: 14px;
+    }
+
+    /* display MacOSX by default */
+    [platform="gnu"] .specialKey .win,
+    [platform="gnu"] .specialKey .mac,
+    [platform="win"] .specialKey .gnu,
+    [platform="win"] .specialKey .mac { display: none; }
+    [platform="mac"] .specialKey .mac,
+    [platform="gnu"] .specialKey .gnu,
+    [platform="win"] .specialKey .win { display: block; }
+
+    /* swap Alt/Meta for MacOSX */
+    [platform="gnu"] #MetaLeft,
+    [platform="win"] #MetaLeft,  #AltLeft   { transform: translate(75px, 0px); }
+    [platform="gnu"] #AltLeft,
+    [platform="win"] #AltLeft,   #MetaLeft  { transform: translate(150px, 0px); }
+    [platform="gnu"] #AltRight,
+    [platform="win"] #AltRight,  #MetaRight { transform: translate(600px, 0px); }
+    [platform="gnu"] #MetaRight,
+    [platform="win"] #MetaRight, #AltRight  { transform: translate(675px, 0px); }
+
+    g:target rect, .press rect,
+    g:target path, .press path {
+      fill: #aad;
+    }
+
+    [theme="reach"] .pinkyKey  rect { fill: hsl(  0, 100%, 90%); }
+    [theme="reach"] .numberKey rect { fill: hsl( 42, 100%, 90%); }
+    [theme="reach"] .letterKey rect { fill: hsl(122, 100%, 90%); }
+    [theme="reach"] .homeKey   rect { fill: hsl(122, 100%, 75%); }
+    [theme="reach"] .press     rect { fill: #aaf; }
+
+    [theme="hints"] [finger="m1"] rect { fill: hsl(  0, 100%, 95%); }
+    [theme="hints"] [finger="l2"] rect { fill: hsl( 42, 100%, 85%); }
+    [theme="hints"] [finger="r2"] rect { fill: hsl( 61, 100%, 85%); }
+    [theme="hints"] [finger="l3"] rect,
+    [theme="hints"] [finger="r3"] rect { fill: hsl(136, 100%, 85%); }
+    [theme="hints"] [finger="l4"] rect,
+    [theme="hints"] [finger="r4"] rect { fill: hsl(200, 100%, 85%); }
+    [theme="hints"] [finger="l5"] rect,
+    [theme="hints"] [finger="r5"] rect { fill: hsl(230, 100%, 85%); }
+    [theme="hints"] .specialKey   rect,
+    [theme="hints"] .specialKey   path { fill: #e4e4e4; }
+    [theme="hints"] .hint         rect { fill: #a33; }
+    [theme="hints"] .press        rect { fill: #335; }
+    [theme="hints"] .press        text { fill: #fff; }
+    [theme="hints"] .hint text {
+      font-weight: bold;
+      fill: white;
+    }
+
+    /* dimmed AltGr + bold dead keys */
+    .level3, .level4 { fill: blue; opacity: .5; }
+    .level5, .level6 { fill: green; }
+    .deadKey {
+      fill: red;
+      font-size: 14px;
+    }
+    .diacritic  {
+      font-size: 20px;
+      font-weight: bolder;
+    }
+
+    /* hide Level4 (Shift+AltGr) unless AltGr is pressed */
+    .level4        { display: none; }
+    .altgr .level4 { display: block; }
+
+    /* highlight AltGr + Dead Keys */
+    .dk .level1, .altgr .level1,
+    .dk .level2, .altgr .level2 { opacity: 0.25; }
+    .dk .level5, .altgr .level3,
+    .dk .level6, .altgr .level4 { opacity: 1; }
+    .dk .level3,
+    .dk .level4 { display: none; }
+
+    @media (prefers-color-scheme: dark) {
+      rect, path { stroke: #777; fill: #444; }
+      .specialKey, .specialKey rect, .specialKey path { fill: #333; }
+      g:target rect, .press rect, g:target path, .press path { fill: #558; }
+      text { fill: #999; }
+      .level3, .level4 { fill: #99f; }
+      .level5, .level6 { fill: #6d6; }
+      .deadKey { fill: #f44; }
+
+      [theme="reach"] .pinkyKey  rect { fill: hsl(  0, 60%, 25%); }
+      [theme="reach"] .numberKey rect { fill: hsl( 42, 60%, 27%); }
+      [theme="reach"] .letterKey rect { fill: hsl(122, 75%, 20%); }
+      [theme="reach"] .homeKey   rect { fill: hsl(122, 70%, 25%); }
+      [theme="reach"] .press     rect { fill: #449; }
+
+      [theme="hints"] [finger="m1"] rect { fill: hsl(  0, 100%, 95%); }
+      [theme="hints"] [finger="l2"] rect { fill: hsl( 42, 100%, 85%); }
+      [theme="hints"] [finger="r2"] rect { fill: hsl( 61, 100%, 85%); }
+      [theme="hints"] [finger="l3"] rect,
+      [theme="hints"] [finger="r3"] rect { fill: hsl(136, 100%, 85%); }
+      [theme="hints"] [finger="l4"] rect,
+      [theme="hints"] [finger="r4"] rect { fill: hsl(200, 100%, 85%); }
+      [theme="hints"] [finger="l5"] rect,
+      [theme="hints"] [finger="r5"] rect { fill: hsl(230, 100%, 85%); }
+      [theme="hints"] .specialKey   rect,
+      [theme="hints"] .specialKey   path { fill: #e4e4e4; }
+      [theme="hints"] .hint         rect { fill: #a33; }
+      [theme="hints"] .press        rect { fill: #335; }
+      [theme="hints"] .press        text { fill: #fff; }
+      [theme="hints"] .hint text {
+        font-weight: bold;
+        fill: white;
+      }
+    }
+  </style>
+  <g id="row_AE" text-anchor="middle">
+    <g class="left">
+      <g class="specialKey" finger="l5" id="Escape" transform="translate(0, 0)">
+        <rect class="ergo" width="67" height="52" rx="5" ry="5"/>
+        <text class="ergo" width="22" height="22" x="16.4" y="42.8">⎋</text>
+      </g>
+      <g class="pinkyKey" finger="l5" id="Backquote" transform="translate(0, 0)">
+        <rect class="specialKey jis" width="52" height="52" rx="5" ry="5"/>
+        <rect class="ansi alt iso" width="52" height="52" rx="5" ry="5"/>
+        <rect class="ol60" width="67" height="52" rx="5" ry="5"/>
+        <text class="jis" width="22" height="22" x="26" y="20">半角</text>
+        <text class="jis" width="22" height="22" x="26" y="32">全角</text>
+        <text class="jis" width="22" height="22" x="26" y="44">漢字</text>
+        <g class="ansi key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="l5" id="Digit1" transform="translate(60, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="l5" id="Digit2" transform="translate(120, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="l4" id="Digit3" transform="translate(180, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="l3" id="Digit4" transform="translate(240, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="l2" id="Digit5" transform="translate(300, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+    </g>
+    <g class="right">
+      <g class="numberKey" finger="l2" id="Digit6" transform="translate(360, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="r2" id="Digit7" transform="translate(420, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="r2" id="Digit8" transform="translate(480, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="r3" id="Digit9" transform="translate(540, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="numberKey" finger="r4" id="Digit0" transform="translate(600, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="Minus" transform="translate(660, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="Equal" transform="translate(720, 0)">
+        <rect class="ansi" width="52" height="52" rx="5" ry="5"/>
+        <rect class="ol60" width="67" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="IntlYen" transform="translate(780, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key"/>
+      </g>
+      <g class="specialKey" finger="r5" id="Backspace" transform="translate(780, 0)">
+        <rect class="ansi" width="112" height="52" rx="5" ry="5"/>
+        <rect class="ol60" width="67" height="112" rx="5" ry="5" y="-60"/>
+        <rect class="ol40 ol50" width="67" height="52" rx="5" ry="5"/>
+        <rect class="alt" width="52" height="52" rx="5" ry="5" x="60"/>
+        <text class="ansi" width="22" height="22" x="16.4" y="42.8">⌫</text>
+        <text class="ergo" width="22" height="22" x="16.4" y="42.8">⌫</text>
+        <text class="alt" width="22" height="22" x="16.4" y="42.8" transform="translate(60, 0)">⌫</text>
+      </g>
+    </g>
+  </g>
+  <g id="row_AD" text-anchor="middle">
+    <g class="left">
+      <g class="specialKey" finger="l5" id="Tab" transform="translate(0, 0)">
+        <rect class="" width="82" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="67" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="16.4" y="42.8">↹</text>
+        <text class="ergo" width="22" height="22" x="16.4" y="42.8">↹</text>
+      </g>
+      <g class="letterKey" finger="l5" id="KeyQ" transform="translate(90, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l4" id="KeyW" transform="translate(150, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l3" id="KeyE" transform="translate(210, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l2" id="KeyR" transform="translate(270, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l2" id="KeyT" transform="translate(330, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+    </g>
+    <g class="right">
+      <g class="letterKey" finger="r2" id="KeyY" transform="translate(390, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r2" id="KeyU" transform="translate(450, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r3" id="KeyI" transform="translate(510, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r4" id="KeyO" transform="translate(570, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r5" id="KeyP" transform="translate(630, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="BracketLeft" transform="translate(690, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="BracketRight" transform="translate(750, 0)">
+        <rect class="ansi" width="52" height="52" rx="5" ry="5"/>
+        <rect class="ol60" width="67" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="Backslash" transform="translate(810, 0)">
+        <rect class="ansi" width="82" height="52" rx="5" ry="5"/>
+        <rect class="iso ol60" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g id="row_AC" text-anchor="middle">
+    <g class="left">
+      <g class="specialKey" finger="l5" id="CapsLock" transform="translate(0, 0)">
+        <rect class="" width="97" height="52" rx="5" ry="5"/>
+        <text class="ansi" width="22" height="22" x="16.4" y="42.8">⇪</text>
+        <text class="jis" width="22" height="22" x="23" y="42.8">英数</text>
+      </g>
+      <g class="letterKey homeKey" finger="l5" id="KeyA" transform="translate(105, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="l4" id="KeyS" transform="translate(165, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="l3" id="KeyD" transform="translate(225, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="l2" id="KeyF" transform="translate(285, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l2" id="KeyG" transform="translate(345, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+    </g>
+    <g class="right">
+      <g class="letterKey" finger="r2" id="KeyH" transform="translate(405, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="r2" id="KeyJ" transform="translate(465, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="r3" id="KeyK" transform="translate(525, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="r4" id="KeyL" transform="translate(585, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey homeKey" finger="r5" id="Semicolon" transform="translate(645, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2 deadKey" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="Quote" transform="translate(705, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="specialKey" finger="r5" id="Enter" transform="translate(765, 0)">
+        <path class="alt" d="M50,-60 h72 a5,5 0 0 1 5,5 v102 a5,5 0 0 1 -5,5 h-117 a5,5 0 0 1 -5,-5 v-42 a5,5 0 0 1 5,-5 h35 a5,5 1 0 0 5,-5 v-50 a5,5 0 0 1 5,-5 z"/>
+        <path class="iso" d="M50,-60 h72 a5,5 0 0 1 5,5 v102 a5,5 0 0 1 -5,5 h-57 a5,5 0 0 1 -5,-5 v-50 a5,5 1 0 0 -5,-5 h-5 a5,5 0 0 1 -5,-5 v-42 a5,5 0 0 1 5,-5 z"/>
+        <rect class="ansi" width="127" height="52" rx="5" ry="5"/>
+        <rect class="ol60" width="67" height="112" rx="5" ry="5" y="-60"/>
+        <rect class="ol40 ol50" width="67" height="52" rx="5" ry="5"/>
+        <text class="ansi alt ergo" width="22" height="22" x="16.4" y="42.8">⏎</text>
+        <text class="iso" width="22" height="22" x="16.4" y="42.8" transform="translate(60, 0)">⏎</text>
+      </g>
+    </g>
+  </g>
+  <g id="row_AB" text-anchor="middle">
+    <g class="left">
+      <g class="specialKey" finger="l5" id="ShiftLeft" transform="translate(0, 0)">
+        <rect class="ansi alt" width="127" height="52" rx="5" ry="5"/>
+        <rect class="iso" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ol50 ol60" width="67" height="112" rx="5" ry="5" y="-60"/>
+        <rect class="ol40" width="67" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="16.4" y="42.8">⇧</text>
+        <text class="ergo" width="22" height="22" x="16.4" y="42.8">⇧</text>
+      </g>
+      <g class="letterKey" finger="l5" id="IntlBackslash" transform="translate(75, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l5" id="KeyZ" transform="translate(135, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l4" id="KeyX" transform="translate(195, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l3" id="KeyC" transform="translate(255, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l2" id="KeyV" transform="translate(315, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="l2" id="KeyB" transform="translate(375, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+    </g>
+    <g class="right">
+      <g class="letterKey" finger="r2" id="KeyN" transform="translate(435, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r2" id="KeyM" transform="translate(495, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r3" id="Comma" transform="translate(555, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4 deadKey diacritic" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r4" id="Period" transform="translate(615, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="letterKey" finger="r5" id="Slash" transform="translate(675, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key">
+          <text class="level1" width="22" height="22" x="12.8" y="43.4"></text>
+          <text class="level2" width="22" height="22" x="12.8" y="20.6"></text>
+          <text class="level3" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level4" width="22" height="22" x="38" y="20.6"></text>
+          <text class="level5 dk" width="22" height="22" x="38" y="43.4"></text>
+          <text class="level6 dk" width="22" height="22" x="38" y="20.6"></text>
+        </g>
+      </g>
+      <g class="pinkyKey" finger="r5" id="IntlRo" transform="translate(735, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <g class="key"/>
+      </g>
+      <g class="specialKey" finger="r5" id="ShiftRight" transform="translate(735, 0)">
+        <rect class="ansi" width="157" height="52" rx="5" ry="5"/>
+        <rect class="abnt" width="97" height="52" rx="5" ry="5" x="60"/>
+        <rect class="ol50 ol60" width="67" height="112" rx="5" ry="5" y="-60"/>
+        <rect class="ol40" width="67" height="52" rx="5" ry="5"/>
+        <text class="ansi" width="22" height="22" x="16.4" y="42.8">⇧</text>
+        <text class="ergo" width="22" height="22" x="16.4" y="42.8">⇧</text>
+        <text class="abnt" width="22" height="22" x="16.4" y="42.8" transform="translate(60, 0)">⇧</text>
+      </g>
+    </g>
+  </g>
+  <g id="row_AA" text-anchor="middle">
+    <g class="left">
+      <g class="specialKey" finger="l5" id="ControlLeft" transform="translate(0, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="67" height="52" rx="5" ry="5"/>
+        <text class="win gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Ctrl</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌃</text>
+      </g>
+      <g class="specialKey" finger="l1" id="MetaLeft" transform="translate(75, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="82" height="52" rx="5" ry="5"/>
+        <text class="win" width="22" height="22" x="11" y="42.8" text-anchor="start">Win</text>
+        <text class="gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Super</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌘</text>
+      </g>
+      <g class="specialKey" finger="l1" id="AltLeft" transform="translate(150, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="82" height="52" rx="5" ry="5"/>
+        <text class="win gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Alt</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌥</text>
+      </g>
+      <g class="specialKey" finger="l1" id="Lang2" transform="translate(225, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="20" y="42.8">한자</text>
+      </g>
+      <g class="specialKey" finger="l1" id="NonConvert" transform="translate(225, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="26" y="42.8">無変換</text>
+      </g>
+    </g>
+    <g class="homeKey" finger="m1" id="Space" transform="translate(225, 0)">
+      <rect class="ansi" width="367" height="52" rx="5" ry="5"/>
+      <rect class="ol60" width="322" height="52" rx="5" ry="5" x="-60"/>
+      <rect class="ol50 ol40" width="262" height="52" rx="5" ry="5"/>
+      <rect class="ks" width="247" height="52" rx="5" ry="5" x="60"/>
+      <rect class="jis" width="187" height="52" rx="5" ry="5" x="60"/>
+    </g>
+    <g class="right">
+      <g class="specialKey" finger="r1" id="Convert" transform="translate(480, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="26" y="42.8">変換</text>
+      </g>
+      <g class="specialKey" finger="r1" id="KanaMode" transform="translate(540, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="26" y="20">カタカナ</text>
+        <text class="" width="22" height="22" x="26" y="32">ひらがな</text>
+        <text class="" width="22" height="22" x="26" y="44">ローマ字</text>
+      </g>
+      <g class="specialKey" finger="r1" id="Lang1" transform="translate(540, 0)">
+        <rect class="" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="20" y="42.8">한/영</text>
+      </g>
+      <g class="specialKey" finger="r1" id="AltRight" transform="translate(600, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="82" height="52" rx="5" ry="5"/>
+        <text class="win gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Alt</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌥</text>
+      </g>
+      <g class="specialKey" finger="r1" id="MetaRight" transform="translate(690, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="82" height="52" rx="5" ry="5"/>
+        <text class="win" width="22" height="22" x="11" y="42.8" text-anchor="start">Win</text>
+        <text class="gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Super</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌘</text>
+      </g>
+      <g class="specialKey" finger="r5" id="ContextMenu" transform="translate(750, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="52" height="52" rx="5" ry="5"/>
+        <text class="" width="22" height="22" x="16.4" y="42.8">☰</text>
+        <text class="ol60" width="22" height="22" x="16.4" y="42.8">☰</text>
+      </g>
+      <g class="specialKey" finger="r5" id="ControlRight" transform="translate(825, 0)">
+        <rect class="" width="67" height="52" rx="5" ry="5"/>
+        <rect class="ergo" width="67" height="52" rx="5" ry="5"/>
+        <text class="win gnu" width="22" height="22" x="11" y="42.8" text-anchor="start">Ctrl</text>
+        <text class="mac" width="22" height="22" x="16.4" y="42.8">⌃</text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -331,13 +331,9 @@ def remove_rules_variant(variant_list, name):
 
 
 def add_rules_variant(variant_list, name, description):
-<<<<<<< HEAD
     variant_list.append(
         E.variant(E.configItem(E.name(name), E.description(description)))
     )
-=======
-    variant_list.append(E.variant(E.configItem(E.name(name), E.description(description))))
->>>>>>> de4a7b4 (fix: Apply black and isort)
 
 
 def update_rules(xkb_root, kb_index):
@@ -361,13 +357,9 @@ def update_rules(xkb_root, kb_index):
                         description = layout.meta["description"]
                         add_rules_variant(vlist[0], name, description)
 
-<<<<<<< HEAD
             tree.write(
                 filepath, pretty_print=True, xml_declaration=True, encoding="utf-8"
             )
-=======
-            tree.write(filepath, pretty_print=True, xml_declaration=True, encoding="utf-8")
->>>>>>> de4a7b4 (fix: Apply black and isort)
             print(f"... {filepath}")
 
         except Exception as exc:

--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -227,7 +227,6 @@ def update_symbols_locale(path, named_layouts):
     text = ""
     modified_text = False
     with open(path, "r+", encoding="utf-8") as symbols:
-
         # look for Kalamine layouts to be updated or removed
         between_marks = False
         closing_mark = ""
@@ -332,9 +331,13 @@ def remove_rules_variant(variant_list, name):
 
 
 def add_rules_variant(variant_list, name, description):
+<<<<<<< HEAD
     variant_list.append(
         E.variant(E.configItem(E.name(name), E.description(description)))
     )
+=======
+    variant_list.append(E.variant(E.configItem(E.name(name), E.description(description))))
+>>>>>>> de4a7b4 (fix: Apply black and isort)
 
 
 def update_rules(xkb_root, kb_index):
@@ -358,9 +361,13 @@ def update_rules(xkb_root, kb_index):
                         description = layout.meta["description"]
                         add_rules_variant(vlist[0], name, description)
 
+<<<<<<< HEAD
             tree.write(
                 filepath, pretty_print=True, xml_declaration=True, encoding="utf-8"
             )
+=======
+            tree.write(filepath, pretty_print=True, xml_declaration=True, encoding="utf-8")
+>>>>>>> de4a7b4 (fix: Apply black and isort)
             print(f"... {filepath}")
 
         except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ dependencies = [
     'lxml',
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "isort"
+]
+
 [project.urls]
 Homepage = "https://github.com/fabi1cazenave/kalamine"
 


### PR DESCRIPTION
This MR adds SVG rending as a new file output. This is generated as any other file type.

To test it, simply run (e.g. for `ergol.toml` file)
```
python -m kalamine.cli --out ergol.svg layouts/ergol.toml
```

To test all rending classes, add `dk`, `altgr`, `mixed` classes to main `svg` tag to display resp. 1st deadkey, altgr and a mixed view layer.