### PR TITLE
Make sure etree.parse gets a string

### DIFF
--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -68,7 +68,7 @@ class XKBManager:
             filepath = self._rootdir / "rules" / filename
             if not filepath.exists():
                 continue
-            tree = etree.parse(filepath, etree.XMLParser(remove_blank_text=True))
+            tree = etree.parse(str(filepath), etree.XMLParser(remove_blank_text=True))
             for variant in tree.xpath("//variant[@type]"):
                 variant.attrib.pop("type")
 
@@ -90,7 +90,7 @@ class XKBManager:
             filepath = self._rootdir / "rules" / filename
             if not filepath.exists():
                 continue
-            tree = etree.parse(filepath)
+            tree = etree.parse(str(filepath))
             if bool(tree.xpath(f'//layout/configItem/name[text()="custom"]')):
                 return True
 


### PR DESCRIPTION
Old versions of lxml (before 4.8.0) cannot take a pathlib.Path object in etree.parse. One could fix a minimal version for lxml but the issue happens only twice and can be fixed by adding five characters.

Fixes #77