### PR TITLE
Fix(keylayout): don’t append actions twice for a given key/key_name combination

### DIFF
--- a/kalamine/generators/keylayout.py
+++ b/kalamine/generators/keylayout.py
@@ -120,11 +120,16 @@ def macos_actions(layout: "KeyboardLayout") -> List[str]:
             ret_actions.append(f"<!--{key_name[1:]} -->")
             continue
 
+        already = []
         for i in [Layer.BASE, Layer.SHIFT, Layer.ALTGR, Layer.ALTGR_SHIFT]:
             if key_name == "spce" or key_name not in layout.layers[i]:
                 continue
 
             key = layout.layers[i][key_name]
+            if key in already:
+                continue
+            already.append(key)
+
             if i and key == layout.layers[Layer.BASE][key_name]:
                 continue
             if key in layout.dead_keys:


### PR DESCRIPTION
Currently, keylayout generator outputs an action twice if you specify one char twice on the same key. (This is a weird corner case indeed! I’m using this as a hack to make sure level 4 chars don’t get “upgraded” to level 3, but it _might_ also have more proper use cases.) This patch adds a check for that, and skips extraneous action copies.