### PR TITLE
do not require old "tomli" on recent Python

### DIFF
--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -4,8 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Type, TypeVar
 
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
 import click
-import tomli
 import yaml
 
 from .utils import (
@@ -32,7 +36,7 @@ def load_layout(layout_path: Path) -> Dict:
                 return yaml.load(file, Loader=yaml.SafeLoader)
 
         with file_path.open(mode="rb") as dfile:
-            return tomli.load(dfile)
+            return tomllib.load(dfile)
 
     try:
         cfg = load_descriptor(layout_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "click>=8.0",
     "livereload",
     "pyyaml",
-    "tomli",
+    "tomli;python_version<'3.11'",
     "progress",
 ]
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 from typing import Dict
 
-import tomli
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 
 def get_layout_dict(filename: str) -> Dict:
@@ -11,4 +14,4 @@ def get_layout_dict(filename: str) -> Dict:
 
     file_path = Path(__file__).parent.parent / f"layouts/{filename}.toml"
     with file_path.open(mode="rb") as file:
-        return tomli.load(file)
+        return tomllib.load(file)


### PR DESCRIPTION
Hi,

`tomli` and `tomllib` are exactly the same thing, but  `tomllib`  is a built-in from Python 3.11

This patch was applied in Debian were we slowly try to get rid of old libraries/backports

https://wiki.debian.org/Python/Backports

greetings