### PR TITLE
fix: bump docutils and Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "click>=8.0",
     "livereload",
@@ -40,6 +40,7 @@ dev = [
     "ruff>=0.8.0",
     "types-PyYAML",
     "twine>=5.1.1",
+    "docutils>=0.22",
 ]
 
 [project.urls]


### PR DESCRIPTION
`docutils>=0.21.post1` is needed by some dependency, however, it is not on PyPI (anymore?), so we need
to explicitely require 0.22. But 0.22 depends on
`Python>=3.9`, so Python needs to be upgraded as well.

Refs: Fixes issue #217