### PR TITLE
Define layout label for XKB (Linux) in metadata

### DIFF
--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -38,6 +38,8 @@ def load_layout(layout_path: Path) -> Dict:
         cfg = load_descriptor(layout_path)
         if "name" not in cfg:
             cfg["name"] = layout_path.stem
+        if not "xkb_label":
+            cfg["xkb_label"] = ""
         if "extends" in cfg:
             parent_path = layout_path.parent / cfg["extends"]
             ext = load_descriptor(parent_path)
@@ -77,6 +79,7 @@ class MetaDescr:
     locale:      str = "us"
     geometry:    str = "ISO"
     description: str = ""
+    xkb_label:   str = ""
     author:      str = "nobody"
     license:     str = ""
     version:     str = "0.0.1"
@@ -96,6 +99,7 @@ CONFIG = {
     "author": "nobody",
     "license": "WTFPL - Do What The Fuck You Want Public License",
     "geometry": "ISO",
+    "xkb_label": "",
 }
 
 SPACEBAR = {

--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -365,12 +365,17 @@ def remove_rules_variant(variant_list: ET.Element, name: str) -> None:
         variant_list.remove(variant)
 
 
-def add_rules_variant(variant_list: ET.Element, name: str, description: str) -> None:
+def add_rules_variant(variant_list: ET.Element, name: str, description: str, xkb_label: str) -> None:
     """Add a <variant/configItem/{name,description> item to <layout/variantList>."""
 
     variant = ET.SubElement(variant_list, "variant")
     config = ET.SubElement(variant, "configItem")
     ET.SubElement(config, "name").text = name
+    if xkb_label != "":
+        # Set the label used notably by Fcitx5 in the systray, see:
+        # https://github.com/fcitx/fcitx5/issues/1555
+        # Note: `shortDescription` MUST appear before `description` for the document to be valid
+        ET.SubElement(config, "shortDescription").text = xkb_label
     ET.SubElement(config, "description").text = description
 
 
@@ -394,8 +399,8 @@ def update_rules(xkb_root: Path, kbd_index: KbdIndex) -> None:
                     remove_rules_variant(vlist, name)
                     if layout is not None:
                         description = layout.meta["description"]
-                        add_rules_variant(vlist, name, description)
-
+                        xkb_label = layout.meta["xkb_label"]
+                        add_rules_variant(vlist, name, description, xkb_label)
             if hasattr(ET, "indent"):  # Python 3.9+
                 ET.indent(tree)
 


### PR DESCRIPTION
Fctix5 (maybe others?) uses (it’s the only option for this feature) the `<shortDescription>`  field in the `evdev.xml` as the label for the layout in the systray (usually it’s the [ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) for the language the layout is associated with, that is `fr` in the case of Ergo-L for example).

See https://github.com/fcitx/fcitx5/issues/1555#issuecomment-4231342757

I would like this feature to be documented but I don’t know how or where I should do that so I would like some guidance on that matter.