### PR TITLE
Fix Apple scan codes (closes #210, #229)

### DIFF
--- a/kalamine/data/scan_codes.yaml
+++ b/kalamine/data/scan_codes.yaml
@@ -113,7 +113,7 @@ osx:
   ab10: 44  # /
 
   # pinky keys
-  tlde: 50  # ~
+  tlde: 10  # ~
   ae11: 27  # -
   ae12: 24  # =
   ae13: 42  # XXX FIXME
@@ -122,7 +122,7 @@ osx:
   ac11: 39  # '
   ab11: 39  # XXX FIXME
   bksl: 42  # \
-  lsgt: 10  # <
+  lsgt: 50  # <
 
 web:
   spce: 'Space'


### PR DESCRIPTION
Tested with the built-in keyboard of a M4 Macbook Air and a random 105-key PC keyboard. I don’t have anything ANSI at hand, but I believe it should work there too.

see #210 and #229 